### PR TITLE
feat: Add SQLite database schema, seed data, and query functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- SQLite database schema with UNIQUE constraint on (radar_date, focus_area, tool_name) and CHECK constraint on classification (issue #4)
+- `seed_db()` function to populate database with 6 mock data items from PRD
+- Query functions: `get_trends_by_date()`, `get_trends_by_focus_area()`, `get_trends_by_classification()`, `get_latest_trends()`, `get_all_trends()`
+- Comprehensive test suite for models, constraints, seed data, and query functions (22 tests)
+- Added setuptools>=69.0.0 to requirements.txt (required for litellm pkg_resources dependency)
+
 ## [0.1.0] - 2026-02-16
 
 ### Scaffolding Complete ✅

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,11 +1,14 @@
 """Database connection and session management."""
 
+import json
 import os
+from typing import Optional
+
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, Session
 from dotenv import load_dotenv
 
-from app.models import Base
+from app.models import Base, Trend
 
 load_dotenv()
 
@@ -15,9 +18,155 @@ engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
+# Mock data from PRD (6 items)
+SEED_DATA = [
+    {
+        "radar_date": "2026-01-30",
+        "focus_area": "voice_ai_ux",
+        "tool_name": "LiveKit Agents",
+        "classification": "signal",
+        "confidence_score": 92,
+        "technical_insight": "Sub-200ms voice-to-voice latency with WebRTC. Supports interruption handling via VAD (Voice Activity Detection). Native Python SDK with async streaming. Published benchmarks show P95 latency <250ms.",
+        "signal_evidence": [
+            "Published latency benchmarks",
+            "Production usage at scale (Daily.co integration)",
+            "Open-source with active technical community",
+        ],
+        "noise_indicators": [],
+        "architectural_verdict": True,
+        "timestamp": "2026-01-30T08:00:00Z",
+    },
+    {
+        "radar_date": "2026-01-30",
+        "focus_area": "voice_ai_ux",
+        "tool_name": "VoiceHype AI",
+        "classification": "noise",
+        "confidence_score": 85,
+        "technical_insight": "Claims 'revolutionary conversational AI' but provides no latency benchmarks. Demo video only, no SDK or architecture documentation available.",
+        "signal_evidence": [],
+        "noise_indicators": [
+            "No published benchmarks",
+            "Marketing language ('revolutionary', 'human-like')",
+            "Demo-only, no production evidence",
+        ],
+        "architectural_verdict": False,
+        "timestamp": "2026-01-30T08:00:00Z",
+    },
+    {
+        "radar_date": "2026-01-30",
+        "focus_area": "agent_orchestration",
+        "tool_name": "LangGraph",
+        "classification": "signal",
+        "confidence_score": 87,
+        "technical_insight": "Graph-based agent orchestration with built-in state persistence. Supports cyclic workflows and human-in-the-loop patterns. Native integration with LangChain tools. Checkpoint API enables workflow recovery.",
+        "signal_evidence": [
+            "Detailed architecture documentation",
+            "Production case studies (multiple enterprises)",
+            "Active GitHub with technical discussions",
+        ],
+        "noise_indicators": [],
+        "architectural_verdict": True,
+        "timestamp": "2026-01-30T08:00:00Z",
+    },
+    {
+        "radar_date": "2026-01-30",
+        "focus_area": "agent_orchestration",
+        "tool_name": "AutoAgent Pro",
+        "classification": "noise",
+        "confidence_score": 78,
+        "technical_insight": "Promises 'fully autonomous agents' but lacks integration documentation. Roadmap-heavy announcements without shipping history.",
+        "signal_evidence": [],
+        "noise_indicators": [
+            "AGI-adjacent marketing claims",
+            "No integration specifications",
+            "Roadmap announcements without releases",
+        ],
+        "architectural_verdict": False,
+        "timestamp": "2026-01-30T08:00:00Z",
+    },
+    {
+        "radar_date": "2026-01-30",
+        "focus_area": "durable_runtime",
+        "tool_name": "Temporal.io",
+        "classification": "signal",
+        "confidence_score": 94,
+        "technical_insight": "Workflow durability with automatic retries and state recovery. Cold-start ~50ms for cached workers. Supports long-running workflows (days/weeks) with checkpoint persistence. Published SLAs for cloud offering.",
+        "signal_evidence": [
+            "Published cold-start benchmarks",
+            "SLA documentation for durability guarantees",
+            "Enterprise production usage (Netflix, Snap)",
+        ],
+        "noise_indicators": [],
+        "architectural_verdict": True,
+        "timestamp": "2026-01-30T08:00:00Z",
+    },
+    {
+        "radar_date": "2026-01-30",
+        "focus_area": "durable_runtime",
+        "tool_name": "InfiniScale Runtime",
+        "classification": "noise",
+        "confidence_score": 81,
+        "technical_insight": "Claims 'infinite scale with zero cold starts' but provides no benchmark data. Private beta with waitlist, no architecture documentation.",
+        "signal_evidence": [],
+        "noise_indicators": [
+            "Impossible claims ('zero cold starts')",
+            "No published benchmarks",
+            "Waitlist-only, no technical docs",
+        ],
+        "architectural_verdict": False,
+        "timestamp": "2026-01-30T08:00:00Z",
+    },
+]
+
+
 def init_db():
     """Initialize the database by creating all tables."""
     Base.metadata.create_all(bind=engine)
+
+
+def seed_db(db: Optional[Session] = None):
+    """Seed the database with mock data from PRD (6 items).
+
+    Args:
+        db: Optional database session. If not provided, creates a new one.
+    """
+    close_session = False
+    if db is None:
+        db = SessionLocal()
+        close_session = True
+
+    try:
+        for item in SEED_DATA:
+            # Check if trend already exists (unique constraint)
+            existing = (
+                db.query(Trend)
+                .filter(
+                    Trend.radar_date == item["radar_date"],
+                    Trend.focus_area == item["focus_area"],
+                    Trend.tool_name == item["tool_name"],
+                )
+                .first()
+            )
+            if existing:
+                continue
+
+            trend = Trend(
+                radar_date=item["radar_date"],
+                focus_area=item["focus_area"],
+                tool_name=item["tool_name"],
+                classification=item["classification"],
+                confidence_score=item["confidence_score"],
+                technical_insight=item["technical_insight"],
+                signal_evidence=json.dumps(item["signal_evidence"]),
+                noise_indicators=json.dumps(item["noise_indicators"]),
+                architectural_verdict=item["architectural_verdict"],
+                timestamp=item["timestamp"],
+            )
+            db.add(trend)
+        db.commit()
+    finally:
+        if close_session:
+            db.close()
 
 
 def get_db():
@@ -27,3 +176,69 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def get_trends_by_date(db: Session, radar_date: str) -> list[Trend]:
+    """Query trends for a specific date.
+
+    Args:
+        db: Database session.
+        radar_date: Date in YYYY-MM-DD format.
+
+    Returns:
+        List of Trend objects for the given date.
+    """
+    return db.query(Trend).filter(Trend.radar_date == radar_date).all()
+
+
+def get_trends_by_focus_area(db: Session, focus_area: str) -> list[Trend]:
+    """Query trends for a specific focus area.
+
+    Args:
+        db: Database session.
+        focus_area: One of 'voice_ai_ux', 'agent_orchestration', 'durable_runtime'.
+
+    Returns:
+        List of Trend objects for the given focus area.
+    """
+    return db.query(Trend).filter(Trend.focus_area == focus_area).all()
+
+
+def get_trends_by_classification(db: Session, classification: str) -> list[Trend]:
+    """Query trends by classification (signal or noise).
+
+    Args:
+        db: Database session.
+        classification: 'signal' or 'noise'.
+
+    Returns:
+        List of Trend objects with the given classification.
+    """
+    return db.query(Trend).filter(Trend.classification == classification).all()
+
+
+def get_latest_trends(db: Session) -> list[Trend]:
+    """Get trends from the most recent radar date.
+
+    Args:
+        db: Database session.
+
+    Returns:
+        List of Trend objects from the latest date.
+    """
+    latest_date = db.query(Trend.radar_date).order_by(Trend.radar_date.desc()).first()
+    if latest_date:
+        return db.query(Trend).filter(Trend.radar_date == latest_date[0]).all()
+    return []
+
+
+def get_all_trends(db: Session) -> list[Trend]:
+    """Get all trends from the database.
+
+    Args:
+        db: Database session.
+
+    Returns:
+        List of all Trend objects.
+    """
+    return db.query(Trend).all()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,6 @@
 """SQLite ORM models for CodeScale Research Radar."""
 
-from sqlalchemy import Column, Integer, String, Boolean, Text
+from sqlalchemy import Column, Integer, String, Boolean, Text, UniqueConstraint, CheckConstraint
 from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
@@ -10,6 +10,10 @@ class Trend(Base):
     """Model for storing radar trend analyses."""
 
     __tablename__ = "trends"
+    __table_args__ = (
+        UniqueConstraint("radar_date", "focus_area", "tool_name", name="uq_trend_date_area_tool"),
+        CheckConstraint("classification IN ('signal', 'noise')", name="ck_classification_valid"),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     radar_date = Column(String, nullable=False)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ pydantic==2.5.3
 python-dotenv==1.0.0
 pytest==7.4.4
 httpx==0.26.0
+setuptools>=69.0.0

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,645 @@
+"""Tests for SQLAlchemy models."""
+
+import json
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base, Trend
+
+
+# Create test database
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    """Set up test database before each test."""
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+class TestTrendModel:
+    """Tests for the Trend model."""
+
+    def test_create_signal_trend(self):
+        """Test creating a signal trend."""
+        db = TestingSessionLocal()
+        trend = Trend(
+            radar_date="2026-01-30",
+            focus_area="voice_ai_ux",
+            tool_name="LiveKit Agents",
+            classification="signal",
+            confidence_score=92,
+            technical_insight="Sub-200ms voice-to-voice latency with WebRTC.",
+            signal_evidence=json.dumps(["Published benchmarks", "Production usage"]),
+            noise_indicators=json.dumps([]),
+            architectural_verdict=True,
+            timestamp="2026-01-30T08:00:00Z",
+        )
+        db.add(trend)
+        db.commit()
+
+        saved = db.query(Trend).first()
+        assert saved.id is not None
+        assert saved.tool_name == "LiveKit Agents"
+        assert saved.classification == "signal"
+        assert saved.confidence_score == 92
+        assert saved.architectural_verdict is True
+        db.close()
+
+    def test_create_noise_trend(self):
+        """Test creating a noise trend."""
+        db = TestingSessionLocal()
+        trend = Trend(
+            radar_date="2026-01-30",
+            focus_area="voice_ai_ux",
+            tool_name="VoiceHype AI",
+            classification="noise",
+            confidence_score=85,
+            technical_insight="Claims 'revolutionary' but no benchmarks.",
+            signal_evidence=json.dumps([]),
+            noise_indicators=json.dumps(["No benchmarks", "Marketing language"]),
+            architectural_verdict=False,
+            timestamp="2026-01-30T08:00:00Z",
+        )
+        db.add(trend)
+        db.commit()
+
+        saved = db.query(Trend).first()
+        assert saved.classification == "noise"
+        assert saved.architectural_verdict is False
+        db.close()
+
+    def test_to_dict_method(self):
+        """Test the to_dict method for JSON serialization."""
+        db = TestingSessionLocal()
+        trend = Trend(
+            radar_date="2026-01-30",
+            focus_area="agent_orchestration",
+            tool_name="LangGraph",
+            classification="signal",
+            confidence_score=87,
+            technical_insight="Graph-based agent orchestration.",
+            signal_evidence=json.dumps(["Architecture docs", "Case studies"]),
+            noise_indicators=json.dumps([]),
+            architectural_verdict=True,
+            timestamp="2026-01-30T08:00:00Z",
+        )
+        db.add(trend)
+        db.commit()
+
+        result = trend.to_dict()
+        assert result["focus_area"] == "agent_orchestration"
+        assert result["tool_name"] == "LangGraph"
+        assert result["classification"] == "signal"
+        assert result["confidence_score"] == 87
+        assert result["signal_evidence"] == ["Architecture docs", "Case studies"]
+        assert result["noise_indicators"] == []
+        assert result["architectural_verdict"] is True
+        assert result["timestamp"] == "2026-01-30T08:00:00Z"
+        db.close()
+
+    def test_to_dict_with_empty_evidence(self):
+        """Test to_dict when evidence fields are None."""
+        db = TestingSessionLocal()
+        trend = Trend(
+            radar_date="2026-01-30",
+            focus_area="durable_runtime",
+            tool_name="TestTool",
+            classification="signal",
+            confidence_score=75,
+            technical_insight="Test insight.",
+            signal_evidence=None,
+            noise_indicators=None,
+            architectural_verdict=True,
+            timestamp="2026-01-30T08:00:00Z",
+        )
+        db.add(trend)
+        db.commit()
+
+        result = trend.to_dict()
+        assert result["signal_evidence"] == []
+        assert result["noise_indicators"] == []
+        db.close()
+
+    def test_query_by_focus_area(self):
+        """Test querying trends by focus area."""
+        db = TestingSessionLocal()
+
+        # Add trends for different focus areas
+        areas = ["voice_ai_ux", "agent_orchestration", "durable_runtime"]
+        for area in areas:
+            trend = Trend(
+                radar_date="2026-01-30",
+                focus_area=area,
+                tool_name=f"Tool for {area}",
+                classification="signal",
+                confidence_score=80,
+                technical_insight="Test insight.",
+                signal_evidence=json.dumps([]),
+                noise_indicators=json.dumps([]),
+                architectural_verdict=True,
+                timestamp="2026-01-30T08:00:00Z",
+            )
+            db.add(trend)
+        db.commit()
+
+        # Query specific focus area
+        voice_trends = db.query(Trend).filter(Trend.focus_area == "voice_ai_ux").all()
+        assert len(voice_trends) == 1
+        assert voice_trends[0].focus_area == "voice_ai_ux"
+        db.close()
+
+    def test_query_by_date(self):
+        """Test querying trends by radar date."""
+        db = TestingSessionLocal()
+
+        # Add trends for different dates
+        dates = ["2026-01-30", "2026-02-06", "2026-02-13"]
+        for date in dates:
+            trend = Trend(
+                radar_date=date,
+                focus_area="voice_ai_ux",
+                tool_name=f"Tool for {date}",
+                classification="signal",
+                confidence_score=80,
+                technical_insight="Test insight.",
+                signal_evidence=json.dumps([]),
+                noise_indicators=json.dumps([]),
+                architectural_verdict=True,
+                timestamp=f"{date}T08:00:00Z",
+            )
+            db.add(trend)
+        db.commit()
+
+        # Query specific date
+        feb_trends = db.query(Trend).filter(Trend.radar_date == "2026-02-06").all()
+        assert len(feb_trends) == 1
+        assert feb_trends[0].radar_date == "2026-02-06"
+        db.close()
+
+    def test_query_by_classification(self):
+        """Test querying trends by classification (signal/noise)."""
+        db = TestingSessionLocal()
+
+        # Add signal trend
+        signal = Trend(
+            radar_date="2026-01-30",
+            focus_area="voice_ai_ux",
+            tool_name="SignalTool",
+            classification="signal",
+            confidence_score=90,
+            technical_insight="Good tool.",
+            signal_evidence=json.dumps(["evidence"]),
+            noise_indicators=json.dumps([]),
+            architectural_verdict=True,
+            timestamp="2026-01-30T08:00:00Z",
+        )
+        # Add noise trend
+        noise = Trend(
+            radar_date="2026-01-30",
+            focus_area="voice_ai_ux",
+            tool_name="NoiseTool",
+            classification="noise",
+            confidence_score=85,
+            technical_insight="Hype tool.",
+            signal_evidence=json.dumps([]),
+            noise_indicators=json.dumps(["hype"]),
+            architectural_verdict=False,
+            timestamp="2026-01-30T08:00:00Z",
+        )
+        db.add(signal)
+        db.add(noise)
+        db.commit()
+
+        signals = db.query(Trend).filter(Trend.classification == "signal").all()
+        assert len(signals) == 1
+        assert signals[0].tool_name == "SignalTool"
+
+        noises = db.query(Trend).filter(Trend.classification == "noise").all()
+        assert len(noises) == 1
+        assert noises[0].tool_name == "NoiseTool"
+        db.close()
+
+    def test_confidence_score_range(self):
+        """Test that confidence scores within valid range work."""
+        db = TestingSessionLocal()
+
+        # Test minimum valid score
+        trend_min = Trend(
+            radar_date="2026-01-30",
+            focus_area="voice_ai_ux",
+            tool_name="MinScore",
+            classification="signal",
+            confidence_score=1,
+            technical_insight="Minimum confidence.",
+            signal_evidence=json.dumps([]),
+            noise_indicators=json.dumps([]),
+            architectural_verdict=True,
+            timestamp="2026-01-30T08:00:00Z",
+        )
+        db.add(trend_min)
+
+        # Test maximum valid score
+        trend_max = Trend(
+            radar_date="2026-01-30",
+            focus_area="voice_ai_ux",
+            tool_name="MaxScore",
+            classification="signal",
+            confidence_score=100,
+            technical_insight="Maximum confidence.",
+            signal_evidence=json.dumps([]),
+            noise_indicators=json.dumps([]),
+            architectural_verdict=True,
+            timestamp="2026-01-30T08:00:00Z",
+        )
+        db.add(trend_max)
+        db.commit()
+
+        min_saved = db.query(Trend).filter(Trend.tool_name == "MinScore").first()
+        max_saved = db.query(Trend).filter(Trend.tool_name == "MaxScore").first()
+        assert min_saved.confidence_score == 1
+        assert max_saved.confidence_score == 100
+        db.close()
+
+
+class TestDatabaseInit:
+    """Tests for database initialization."""
+
+    def test_init_db_creates_tables(self):
+        """Test that init_db creates the trends table."""
+        from app.database import init_db, engine as app_engine
+        from app.models import Base
+
+        # Create a fresh engine for this test
+        test_engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+        )
+
+        # Bind base to test engine
+        Base.metadata.create_all(bind=test_engine)
+
+        # Check table exists
+        from sqlalchemy import inspect
+
+        inspector = inspect(test_engine)
+        tables = inspector.get_table_names()
+        assert "trends" in tables
+
+    def test_trends_table_has_correct_columns(self):
+        """Test that trends table has all required columns."""
+        from sqlalchemy import inspect
+
+        inspector = inspect(engine)
+        columns = {col["name"] for col in inspector.get_columns("trends")}
+
+        expected_columns = {
+            "id",
+            "radar_date",
+            "focus_area",
+            "tool_name",
+            "classification",
+            "confidence_score",
+            "technical_insight",
+            "signal_evidence",
+            "noise_indicators",
+            "architectural_verdict",
+            "timestamp",
+        }
+        assert expected_columns == columns
+
+
+class TestUniqueConstraint:
+    """Tests for the unique constraint on (radar_date, focus_area, tool_name)."""
+
+    def test_unique_constraint_prevents_duplicates(self):
+        """Test that duplicate (radar_date, focus_area, tool_name) entries are rejected."""
+        from sqlalchemy.exc import IntegrityError
+
+        db = TestingSessionLocal()
+        trend1 = Trend(
+            radar_date="2026-01-30",
+            focus_area="voice_ai_ux",
+            tool_name="DuplicateTool",
+            classification="signal",
+            confidence_score=90,
+            technical_insight="First entry.",
+            signal_evidence=json.dumps([]),
+            noise_indicators=json.dumps([]),
+            architectural_verdict=True,
+            timestamp="2026-01-30T08:00:00Z",
+        )
+        db.add(trend1)
+        db.commit()
+
+        # Try to add duplicate
+        trend2 = Trend(
+            radar_date="2026-01-30",
+            focus_area="voice_ai_ux",
+            tool_name="DuplicateTool",
+            classification="noise",
+            confidence_score=80,
+            technical_insight="Duplicate entry.",
+            signal_evidence=json.dumps([]),
+            noise_indicators=json.dumps([]),
+            architectural_verdict=False,
+            timestamp="2026-01-30T09:00:00Z",
+        )
+        db.add(trend2)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+        db.close()
+
+    def test_same_tool_different_date_allowed(self):
+        """Test that same tool on different dates is allowed."""
+        db = TestingSessionLocal()
+        trend1 = Trend(
+            radar_date="2026-01-30",
+            focus_area="voice_ai_ux",
+            tool_name="SameTool",
+            classification="signal",
+            confidence_score=90,
+            technical_insight="Week 1.",
+            signal_evidence=json.dumps([]),
+            noise_indicators=json.dumps([]),
+            architectural_verdict=True,
+            timestamp="2026-01-30T08:00:00Z",
+        )
+        trend2 = Trend(
+            radar_date="2026-02-06",
+            focus_area="voice_ai_ux",
+            tool_name="SameTool",
+            classification="signal",
+            confidence_score=92,
+            technical_insight="Week 2.",
+            signal_evidence=json.dumps([]),
+            noise_indicators=json.dumps([]),
+            architectural_verdict=True,
+            timestamp="2026-02-06T08:00:00Z",
+        )
+        db.add(trend1)
+        db.add(trend2)
+        db.commit()
+
+        # Both should be saved
+        results = db.query(Trend).filter(Trend.tool_name == "SameTool").all()
+        assert len(results) == 2
+        db.close()
+
+
+class TestClassificationConstraint:
+    """Tests for the classification check constraint."""
+
+    def test_invalid_classification_rejected(self):
+        """Test that invalid classification values are rejected."""
+        from sqlalchemy.exc import IntegrityError
+
+        db = TestingSessionLocal()
+        trend = Trend(
+            radar_date="2026-01-30",
+            focus_area="voice_ai_ux",
+            tool_name="InvalidTool",
+            classification="invalid_value",  # Invalid!
+            confidence_score=90,
+            technical_insight="Invalid classification.",
+            signal_evidence=json.dumps([]),
+            noise_indicators=json.dumps([]),
+            architectural_verdict=True,
+            timestamp="2026-01-30T08:00:00Z",
+        )
+        db.add(trend)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+        db.close()
+
+
+class TestSeedDatabase:
+    """Tests for the seed_db function."""
+
+    def test_seed_db_creates_6_records(self):
+        """Test that seed_db creates exactly 6 records from PRD mock data."""
+        from app.database import seed_db, SEED_DATA
+
+        db = TestingSessionLocal()
+
+        # Verify empty database
+        assert db.query(Trend).count() == 0
+
+        seed_db(db)
+
+        # Check 6 records created
+        assert db.query(Trend).count() == 6
+        db.close()
+
+    def test_seed_db_is_idempotent(self):
+        """Test that seed_db can be called multiple times without creating duplicates."""
+        from app.database import seed_db
+
+        db = TestingSessionLocal()
+
+        seed_db(db)
+        assert db.query(Trend).count() == 6
+
+        # Call again - should not create duplicates
+        seed_db(db)
+        assert db.query(Trend).count() == 6
+        db.close()
+
+    def test_seed_db_data_matches_prd(self):
+        """Test that seeded data matches the PRD specifications."""
+        from app.database import seed_db
+
+        db = TestingSessionLocal()
+        seed_db(db)
+
+        # Check for LiveKit Agents (signal)
+        livekit = db.query(Trend).filter(Trend.tool_name == "LiveKit Agents").first()
+        assert livekit is not None
+        assert livekit.classification == "signal"
+        assert livekit.confidence_score == 92
+        assert livekit.focus_area == "voice_ai_ux"
+
+        # Check for VoiceHype AI (noise)
+        voicehype = db.query(Trend).filter(Trend.tool_name == "VoiceHype AI").first()
+        assert voicehype is not None
+        assert voicehype.classification == "noise"
+        assert voicehype.architectural_verdict is False
+
+        # Check for Temporal.io (signal)
+        temporal = db.query(Trend).filter(Trend.tool_name == "Temporal.io").first()
+        assert temporal is not None
+        assert temporal.classification == "signal"
+        assert temporal.confidence_score == 94
+        assert temporal.focus_area == "durable_runtime"
+
+        db.close()
+
+
+class TestQueryFunctions:
+    """Tests for the database query functions."""
+
+    def test_get_trends_by_date(self):
+        """Test get_trends_by_date returns correct trends."""
+        from app.database import get_trends_by_date
+
+        db = TestingSessionLocal()
+
+        # Add trends for different dates
+        for date in ["2026-01-30", "2026-02-06"]:
+            for i in range(2):
+                trend = Trend(
+                    radar_date=date,
+                    focus_area="voice_ai_ux",
+                    tool_name=f"Tool {date}-{i}",
+                    classification="signal",
+                    confidence_score=80,
+                    technical_insight="Test.",
+                    signal_evidence=json.dumps([]),
+                    noise_indicators=json.dumps([]),
+                    architectural_verdict=True,
+                    timestamp=f"{date}T08:00:00Z",
+                )
+                db.add(trend)
+        db.commit()
+
+        results = get_trends_by_date(db, "2026-01-30")
+        assert len(results) == 2
+        for trend in results:
+            assert trend.radar_date == "2026-01-30"
+        db.close()
+
+    def test_get_trends_by_focus_area(self):
+        """Test get_trends_by_focus_area returns correct trends."""
+        from app.database import get_trends_by_focus_area
+
+        db = TestingSessionLocal()
+
+        # Add trends for different focus areas
+        areas = ["voice_ai_ux", "agent_orchestration", "durable_runtime"]
+        for area in areas:
+            trend = Trend(
+                radar_date="2026-01-30",
+                focus_area=area,
+                tool_name=f"Tool for {area}",
+                classification="signal",
+                confidence_score=80,
+                technical_insight="Test.",
+                signal_evidence=json.dumps([]),
+                noise_indicators=json.dumps([]),
+                architectural_verdict=True,
+                timestamp="2026-01-30T08:00:00Z",
+            )
+            db.add(trend)
+        db.commit()
+
+        results = get_trends_by_focus_area(db, "agent_orchestration")
+        assert len(results) == 1
+        assert results[0].focus_area == "agent_orchestration"
+        db.close()
+
+    def test_get_trends_by_classification(self):
+        """Test get_trends_by_classification returns correct trends."""
+        from app.database import get_trends_by_classification
+
+        db = TestingSessionLocal()
+
+        # Add signals and noise
+        for i, cls in enumerate(["signal", "signal", "noise"]):
+            trend = Trend(
+                radar_date="2026-01-30",
+                focus_area="voice_ai_ux",
+                tool_name=f"Tool {i}",
+                classification=cls,
+                confidence_score=80,
+                technical_insight="Test.",
+                signal_evidence=json.dumps([]),
+                noise_indicators=json.dumps([]),
+                architectural_verdict=cls == "signal",
+                timestamp="2026-01-30T08:00:00Z",
+            )
+            db.add(trend)
+        db.commit()
+
+        signals = get_trends_by_classification(db, "signal")
+        assert len(signals) == 2
+
+        noises = get_trends_by_classification(db, "noise")
+        assert len(noises) == 1
+        db.close()
+
+    def test_get_latest_trends(self):
+        """Test get_latest_trends returns trends from most recent date."""
+        from app.database import get_latest_trends
+
+        db = TestingSessionLocal()
+
+        # Add trends for different dates
+        dates = ["2026-01-30", "2026-02-06", "2026-02-13"]
+        for date in dates:
+            trend = Trend(
+                radar_date=date,
+                focus_area="voice_ai_ux",
+                tool_name=f"Tool for {date}",
+                classification="signal",
+                confidence_score=80,
+                technical_insight="Test.",
+                signal_evidence=json.dumps([]),
+                noise_indicators=json.dumps([]),
+                architectural_verdict=True,
+                timestamp=f"{date}T08:00:00Z",
+            )
+            db.add(trend)
+        db.commit()
+
+        results = get_latest_trends(db)
+        assert len(results) == 1
+        assert results[0].radar_date == "2026-02-13"
+        db.close()
+
+    def test_get_latest_trends_empty_db(self):
+        """Test get_latest_trends returns empty list on empty database."""
+        from app.database import get_latest_trends
+
+        db = TestingSessionLocal()
+        results = get_latest_trends(db)
+        assert results == []
+        db.close()
+
+    def test_get_all_trends(self):
+        """Test get_all_trends returns all records."""
+        from app.database import get_all_trends
+
+        db = TestingSessionLocal()
+
+        # Add some trends
+        for i in range(5):
+            trend = Trend(
+                radar_date="2026-01-30",
+                focus_area="voice_ai_ux",
+                tool_name=f"Tool {i}",
+                classification="signal",
+                confidence_score=80,
+                technical_insight="Test.",
+                signal_evidence=json.dumps([]),
+                noise_indicators=json.dumps([]),
+                architectural_verdict=True,
+                timestamp="2026-01-30T08:00:00Z",
+            )
+            db.add(trend)
+        db.commit()
+
+        results = get_all_trends(db)
+        assert len(results) == 5
+        db.close()


### PR DESCRIPTION
## Summary
- Add UNIQUE constraint on (radar_date, focus_area, tool_name) to prevent duplicate entries
- Add CHECK constraint on classification to enforce 'signal' or 'noise' values only
- Add `seed_db()` function with 6 mock data items from PRD (LiveKit Agents, VoiceHype AI, LangGraph, AutoAgent Pro, Temporal.io, InfiniScale Runtime)
- Add query functions: `get_trends_by_date()`, `get_trends_by_focus_area()`, `get_trends_by_classification()`, `get_latest_trends()`, `get_all_trends()`
- Add comprehensive test suite (22 tests) covering models, constraints, seed data, and query functions
- Add setuptools>=69.0.0 to requirements.txt (required for litellm pkg_resources dependency)

## Testing Done
- [x] `npm run lint` passes (0 errors)
- [x] `pytest` passes (52 tests pass)
- [x] Database initialization verified: `init_db()` creates tables with correct schema
- [x] Database seeding verified: `seed_db()` creates 6 records (verified with `sqlite3 radar.db "SELECT COUNT(*) FROM trends"`)

## Issue
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)